### PR TITLE
Feature/improving brazilian cities recognizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ htmlcov
 .mr.developer.cfg
 .project
 .pydevproject
+pip-selfcheck.json
+share/
+pyvenv.cfg
 
 # Complexity
 output/*.html

--- a/geotext/geotext.py
+++ b/geotext/geotext.py
@@ -103,8 +103,10 @@ class GeoText(object):
     index = build_index()
 
     def __init__(self, text):
-        city_regex = r"[A-Z]+[a-zà-ú]*(?:[ '-][A-Z]+[a-zà-ú]*)*"
+        city_regex = r"[A-ZÀ-Ú]+[a-zà-ú]+[ \-]?(?:d[a-u].)?(?:[A-ZÀ-Ú]+[a-zà-ú]+)*"
         candidates = re.findall(city_regex, text)
+        # Removing white spaces from candidates
+        candidates = [candidate.strip() for candidate in candidates]
         self.countries = [each for each in candidates
                           if each.lower() in self.index.countries]
         self.cities = [each for each in candidates

--- a/tests/test_geotext.py
+++ b/tests/test_geotext.py
@@ -17,15 +17,79 @@ class TestGeotext(unittest.TestCase):
 
     def test_cities(self):
 
-        text = """São Paulo é a capital do estado de São Paulo. As cidades de Baruerí
+        text = """São Paulo é a capital do estado de São Paulo. As cidades de Barueri
                   e Carapicuíba fazem parte da Grade São Paulo. O Rio de Janeiro
                   continua lindo. No carnaval eu vou para Salvador. No reveillon eu 
                   quero ir para Santos."""
         result = geotext.GeoText(text).cities
         expected = [
-            'São Paulo', 'São Paulo', 'Carapicuíba', 'Salvador', 'Santos'
+            'São Paulo', 'São Paulo', 'Barueri', 'Carapicuíba', 'Rio de Janeiro', 'Salvador', 'Santos'
         ]
         self.assertEqual(result, expected)
+
+        brazillians_northeast_capitals = """As capitais do nordeste brasileiro são:
+                                            Salvador na Bahia, 
+                                            Recife em Pernambuco, 
+                                            Natal fica no Rio Grande do Norte, 
+                                            João Pessoa fica na Paraíba, 
+                                            Fortaleza fica no Ceará, 
+                                            Teresina no Piauí, 
+                                            Aracaju em Sergipe,
+                                            Maceió em Alagoas e 
+                                            São Luís no Maranhão."""
+        result = geotext.GeoText(brazillians_northeast_capitals).cities
+        # PS: 'Rio Grande' is not a northeast city, but is a brazilian city
+        expected = [
+            'Salvador', 'Recife', 'Natal', 'Rio Grande', 'João Pessoa', 'Fortaleza', 'Teresina', 'Aracaju', 'Maceió', 'São Luís'
+        ]
+        self.assertEqual(result, expected)
+
+
+        brazillians_north_capitals = """As capitais dos estados do norte brasileiro são: 
+                                        Manaus no Amazonas, 
+                                        Palmas em Tocantins,
+                                        Belém no Pará,
+                                        Acre no Rio Branco."""
+        result = geotext.GeoText(brazillians_north_capitals).cities
+        expected = [
+            'Manaus', 'Palmas', 'Belém', 'Rio Branco'
+        ]
+        self.assertEqual(result, expected)
+
+        brazillians_southeast_capitals = """As capitais da região sudeste do Brasil são:
+                                            Rio de Janeiro no Rio de Janeiro,
+                                            São Paulo em São Paulo,
+                                            Belo Horizonte em Minas Gerais,
+                                            Vitória no Espírito Santo"""
+        result = geotext.GeoText(brazillians_southeast_capitals).cities
+        # 'Rio de Janeiro' and 'Sao Paulo' city and state name are the same, so appears 2 times, it's ok!
+        expected = [
+            'Rio de Janeiro', 'Rio de Janeiro', 'São Paulo', 'São Paulo', 'Belo Horizonte', 'Vitória'
+        ]
+        self.assertEqual(result, expected)
+
+        brazillians_central_capitals = """As capitais da região centro-oeste do Brasil são: 
+                                          Goiânia em Goiás, 
+                                          Brasília no Distrito Federal,
+                                          Campo Grande no Mato Grosso do Sul,
+                                          Cuiabá no Mato Grosso."""
+        result = geotext.GeoText(brazillians_central_capitals).cities
+        expected = [
+            'Goiânia', 'Goiás', 'Brasília', 'Campo Grande', 'Cuiabá'
+        ]
+        self.assertEqual(result, expected)
+
+        brazillians_south_capitals = """As capitais da região sul são:
+                                        Porto Alegre no Rio Grande do Sul,
+                                        Floripa em Santa Catarina, 
+                                        Curitiba no Paraná"""
+        result = geotext.GeoText(brazillians_south_capitals).cities
+        # PS: 'Rio Grande' is not a south city, but is a brazilian city
+        expected = [
+            'Porto Alegre', 'Rio Grande', 'Santa Catarina', 'Curitiba', 'Paraná'
+        ]
+        self.assertEqual(result, expected)
+
 
     def test_nationalities(self):
 


### PR DESCRIPTION
Adding ability to recognize all brazilians cities capitals. 
Before this commit, city like "Rio de Janeiro" was never recognized.

In text:

> São Paulo é a capital do estado de São Paulo. As cidades de Barueri e Carapicuíba fazem parte da Grade São Paulo. O Rio de Janeiro continua lindo. No carnaval eu vou para Salvador. No reveillon eu                    quero ir para Santos.

We expect: 
```
['São Paulo', 'São Paulo', 'Barueri', 'Carapicuíba', 'Rio de Janeiro', 'Salvador', 'Santos']
```
And not:
```
[ 'São Paulo', 'São Paulo', 'Carapicuíba', 'Salvador', 'Santos' ]
```
