### PR TITLE
Use population to choose country_mention for ambiguous cities

### DIFF
--- a/tests/test_geotext.py
+++ b/tests/test_geotext.py
@@ -112,6 +112,13 @@ class TestGeotext(unittest.TestCase):
         expected = ['Japan', 'Italy', 'Germany']
         self.assertEqual(result, expected)
 
+    def test_country_mentions(self):
+
+        text = 'I would like to visit Lima, Dublin and Moscow (Russia).'
+        result = geotext.GeoText(text).country_mentions
+        expected = {'PE': 1, 'IE': 1, 'RU': 2}
+        self.assertEqual(result, expected)
+
     def tearDown(self):
         pass
 


### PR DESCRIPTION
When multiple cities have the same name, GeoText uses
whatever appears last in the cities15000.txt file to
determine what country that city belongs to.  This means
text like "Lima, Moscow, Ottawa" gets mapped to {'US': 3}
instead of {'PE': 1, 'RU': 1, 'CA': 1}.

Sort the cities file by population so that bigger cities
get precedence for country_mentions:

> sort -t$'\t' -k 15 -n cities15000.txt > sorted_cities.txt
> mv sorted_cities.txt cities15000.txt