### PR TITLE
fix README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Usage
         # "London"
 
         # filter by country code
-        result = geotext.GeoText('I loved Rio de Janeiro and Havana', 'BR').cities
+        result = GeoText('I loved Rio de Janeiro and Havana', 'BR').cities
         # 'Rio de Janeiro'
         
         GeoText('New York, Texas, and also China').country_mentions


### PR DESCRIPTION
There is no need to reference `geotext` due to the type of import